### PR TITLE
Validator refactor

### DIFF
--- a/incident-application-form/lib/validation/your-details.js
+++ b/incident-application-form/lib/validation/your-details.js
@@ -1,0 +1,55 @@
+const validator = require("validator");
+
+module.exports = {
+  validate: ({ notifierType, contactName }, i18n) => {
+    const validated = {
+      contactName: {
+        isValid: false,
+        messages: [],
+        value: "",
+      },
+      notifierType: {
+        isValid: false,
+        messages: [],
+        value: "",
+      },
+    };
+
+    if (!notifierType || validator.isEmpty(notifierType)) {
+      validated.notifierType.messages.push(
+        i18n.notifierType.validation.required[i18n.languageCode]
+      );
+    }
+
+    if (!contactName || validator.isEmpty(contactName)) {
+      validated.contactName.messages.push(
+        i18n.contactName.validation.required[i18n.languageCode]
+      );
+    }
+
+    if (contactName && !validator.isLength(contactName, { min: 1, max: 100 })) {
+      validated.contactName.messages.push(
+        i18n.contactName.validation.invalidLength[i18n.languageCode]
+      );
+    }
+
+    const isValidContactName = validated.contactName.messages.length === 0;
+    const isValidNotifierType = validated.notifierType.messages.length === 0;
+
+    return {
+      isValid: isValidContactName && isValidNotifierType,
+      validatedFields: {
+        contactName: {
+          isValid: isValidContactName,
+          messages: validated.contactName.messages,
+          value: (contactName && validator.escape(contactName)) || "",
+        },
+        notifierType: {
+          isValid: isValidNotifierType,
+          messages: validated.notifierType.messages,
+          value: (notifierType && validator.escape(notifierType)) || "",
+        },
+      },
+    };
+  },
+};

--- a/incident-application-form/lib/validation/your-details.spec.js
+++ b/incident-application-form/lib/validation/your-details.spec.js
@@ -1,0 +1,139 @@
+const { validate } = require("../validation/your-details");
+
+const translations = require(`${__dirname}/../../translations/your-details.json`);
+
+describe(`lib/validation/your-details`, () => {
+  const testCases = (languageCode) => [
+    [
+      "missing all fields",
+      {},
+      {
+        isValid: false,
+        validatedFields: {
+          contactName: {
+            isValid: false,
+            messages: [
+              translations.contactName.validation.required[languageCode],
+            ],
+            value: "",
+          },
+          notifierType: {
+            isValid: false,
+            messages: [
+              translations.notifierType.validation.required[languageCode],
+            ],
+            value: "",
+          },
+        },
+      },
+    ],
+    [
+      "provided fields are empty",
+      {
+        contactName: "",
+        notifierType: "",
+      },
+      {
+        isValid: false,
+        validatedFields: {
+          contactName: {
+            isValid: false,
+            messages: [
+              translations.contactName.validation.required[languageCode],
+            ],
+            value: "",
+          },
+          notifierType: {
+            isValid: false,
+            messages: [
+              translations.notifierType.validation.required[languageCode],
+            ],
+            value: "",
+          },
+        },
+      },
+    ],
+    [
+      "contact name is too long",
+      {
+        contactName: "a".repeat(101),
+        notifierType: "valid",
+      },
+      {
+        isValid: false,
+        validatedFields: {
+          contactName: {
+            isValid: false,
+            messages: [
+              translations.contactName.validation.invalidLength[languageCode],
+            ],
+            value: "a".repeat(101),
+          },
+          notifierType: {
+            isValid: true,
+            messages: [],
+            value: "valid",
+          },
+        },
+      },
+    ],
+    [
+      "values are escaped",
+      {
+        contactName: "<script>tag here</script>",
+        notifierType: "flowers+%3Cscript%3Eevil_script()%3C/script%3E",
+      },
+      {
+        isValid: true,
+        validatedFields: {
+          contactName: {
+            isValid: true,
+            messages: [],
+            value: "&lt;script&gt;tag here&lt;&#x2F;script&gt;",
+          },
+          notifierType: {
+            isValid: true,
+            messages: [],
+            value: "flowers+%3Cscript%3Eevil_script()%3C&#x2F;script%3E",
+          },
+        },
+      },
+    ],
+    [
+      "happy path",
+      {
+        contactName: "valid",
+        notifierType: "valid",
+      },
+      {
+        isValid: true,
+        validatedFields: {
+          contactName: {
+            isValid: true,
+            messages: [],
+            value: "valid",
+          },
+          notifierType: {
+            isValid: true,
+            messages: [],
+            value: "valid",
+          },
+        },
+      },
+    ],
+  ];
+
+  ["en", "cy"].forEach((languageCode) => {
+    test.each(testCases(languageCode))(
+      `%s - ${languageCode}`,
+      (description, given, expected) => {
+        const i18n = {
+          languageCode,
+          ...translations,
+        };
+
+        expect(validate(given, i18n)).toEqual(expected);
+      }
+    );
+  });
+});

--- a/incident-application-form/package-lock.json
+++ b/incident-application-form/package-lock.json
@@ -1930,15 +1930,6 @@
         }
       }
     },
-    "express-validator": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.6.1.tgz",
-      "integrity": "sha512-+MrZKJ3eGYXkNF9p9Zf7MS7NkPJFg9MDYATU5c80Cf4F62JdLBIjWxy6481tRC0y1NnC9cgOw8FuN364bWaGhA==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "validator": "^13.1.1"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3473,7 +3464,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/incident-application-form/package.json
+++ b/incident-application-form/package.json
@@ -11,11 +11,11 @@
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "express": "~4.16.1",
-    "express-validator": "^6.6.1",
     "http-errors": "~1.6.3",
     "jade": "~1.11.0",
     "morgan": "~1.9.1",
-    "nunjucks": "^3.2.2"
+    "nunjucks": "^3.2.2",
+    "validator": "^13.1.17"
   },
   "devDependencies": {
     "jest": "^26.5.3",

--- a/incident-application-form/routes/your-details.js
+++ b/incident-application-form/routes/your-details.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { body, validationResult } = require("express-validator");
+const { validate } = require("../lib/validation/your-details");
 
 const router = express.Router();
 
@@ -19,36 +19,32 @@ router.get("/", function (req, res, next) {
   res.render(template, { title, i18n });
 });
 
-router.post("/", [
-  body(
-    "notifier-type",
-    i18n.notifierType.validation.required[i18n.languageCode]
-  )
-    .trim()
-    .notEmpty()
-    .escape(),
-  body("contact-name", "Contact name is required")
-    .trim()
-    .isLength(1, 100)
-    .escape(),
+router.post("/", function (req, res, next) {
+  const {
+    "notifier-type": notifierType,
+    "contact-name": contactName,
+    position,
+    organisation,
+  } = req.body;
 
-  function (req, res, next) {
-    const errors = validationResult(req);
+  const validation = validate(
+    { notifierType, contactName, position, organisation },
+    i18n
+  );
 
-    if (!errors.isEmpty()) {
-      res.render(template, {
-        title,
-        errors: errors.mapped(),
-        i18n,
-      });
-      return;
-    }
+  if (!validation.isValid) {
+    res.render(template, {
+      title,
+      validation,
+      i18n,
+    });
+    return;
+  }
 
-    // the valid form submission data
-    console.log(`req`, req.body);
+  // the valid form submission data
+  console.log(`validation`, validation.validatedFields);
 
-    res.render(template, { title, i18n });
-  },
-]);
+  res.render(template, { title, i18n });
+});
 
 module.exports = router;

--- a/incident-application-form/translations/your-details.json
+++ b/incident-application-form/translations/your-details.json
@@ -9,6 +9,22 @@
       "en": "Your Details"
     }
   },
+  "contactName": {
+    "label": {
+      "cy": "Enw Cyswllt",
+      "en": "Contact Name"
+    },
+    "validation": {
+      "required": {
+        "cy": "Mae angen enw cyswllt",
+        "en": "Contact name is required"
+      },
+      "invalidLength": {
+        "cy": "Rhaid i'r enw cyswllt fod rhwng 1 a 100 nod",
+        "en": "Contact name must be between 1 and 100 characters"
+      }
+    }
+  },
   "notifierType": {
     "label": {
       "cy": "Math Hysbysydd",

--- a/incident-application-form/translations/your-details.json
+++ b/incident-application-form/translations/your-details.json
@@ -25,6 +25,12 @@
       }
     }
   },
+  "country": {
+    "label": {
+      "cy": "Gwlad",
+      "en": "Country"
+    }
+  },
   "notifierType": {
     "label": {
       "cy": "Math Hysbysydd",

--- a/incident-application-form/views/your-details.njk
+++ b/incident-application-form/views/your-details.njk
@@ -12,13 +12,19 @@
         <label for="notifier-type">{{ i18n.notifierType.label[i18n.languageCode] }}:</label>
 
         <select data-cy="notifier-type" name="notifier-type" id="notifier-type">
-            <option value="">--{{ i18n.notifierType.defaultValue[i18n.languageCode] }}--</option>
-            <option value="industry">{{ i18n.notifierType.industry[i18n.languageCode] }}</option>
-            <option value="local-authority">{{ i18n.notifierType.localAuthority[i18n.languageCode] }}</option>
+            <option value="">--{{ i18n.notifierType.values.defaultValue[i18n.languageCode] }}--</option>
+            <option value="industry">{{ i18n.notifierType.values.industry[i18n.languageCode] }}</option>
+            <option value="local-authority">{{ i18n.notifierType.values.localAuthority[i18n.languageCode] }}</option>
         </select>
 
-        {% if errors and errors['notifier-type'] %}
-            <div data-cy="notifier-type-errors" id="notifier-type-errors">{{ errors['notifier-type'].msg }}</div>
+        {% if validation and validation.validatedFields.notifierType %}
+            <div data-cy="notifier-type-errors" id="notifier-type-errors">
+                <ul>
+                {% for message in validation.validatedFields.notifierType.messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+                </ul>
+            </div>
         {% endif %}
 
 
@@ -35,8 +41,14 @@
                maxlength="100"
         />
 
-        {% if errors and errors['contact-name'] %}
-            <div data-cy="contact-name-errors" id="contact-name-errors">{{ errors['contact-name'].msg }}</div>
+        {% if validation and validation.validatedFields.contactName %}
+            <div data-cy="contact-name-errors" id="contact-name-errors">
+                <ul>
+                {% for message in validation.validatedFields.contactName.messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+                </ul>
+            </div>
         {% endif %}
 
 
@@ -51,8 +63,14 @@
                maxlength="100"
         />
 
-        {% if errors and errors['position'] %}
-            <div data-cy="position-errors" id="position-errors">{{ errors['position'].msg }}</div>
+        {% if validation and validation.validatedFields.position %}
+            <div data-cy="position-errors" id="position-errors">
+                <ul>
+                {% for message in validation.validatedFields.position.messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+                </ul>
+            </div>
         {% endif %}
 
 
@@ -67,8 +85,14 @@
                maxlength="100"
         />
 
-        {% if errors and errors['organisation'] %}
-            <div data-cy="organisation-errors" id="organisation-errors">{{ errors['organisation'].msg }}</div>
+        {% if validation and validation.validatedFields.organisation %}
+            <div data-cy="organisation-errors" id="organisation-errors">
+                <ul>
+                {% for message in validation.validatedFields.organisation.messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+                </ul>
+            </div>
         {% endif %}
 
 

--- a/incident-application-form/views/your-details.njk
+++ b/incident-application-form/views/your-details.njk
@@ -242,7 +242,7 @@
 
 <br/>
 
-        <label for="address.country">{{ i18n.country.label }}:</label>
+        <label for="address.country">{{ i18n.country.label[i18n.languageCode] }}:</label>
 
         <select data-cy="address.country" name="address.country" id="address.country">
             <option value="">--{{ i18n.country.defaultValue }}--</option>


### PR DESCRIPTION
Builds on the translation refactor. 

Switches to using the raw `validator` library, rather than the express wrapper. This allows validation on our terms, rather than only when `POST`ing in data.

